### PR TITLE
Prevent email blocking

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
       -Discord: k24a1#0180<br>
       -MacRumors Forums: k24a1<br>
       -YouTube: k24a1 under "channels"<br>
-	  -Email: k24a1@hotmail.com
+	  -Email: k24a1<span>@</span>hotmail<span>.</span>com
       <p>This page just acts like an information resource. I host files, do writeups on my projects, and post random stuff on my blog.</p>
       Click on one of the boxes on the left side to explore the website!
     <td width="27" height="187" valign="top" align="left"> 


### PR DESCRIPTION
Site is routed through cloudflare and cloudflare likes to replace emails if you don't have javascript enabled and you can't disable it